### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/stakater/bugs.png?label=ready&title=Ready)](https://waffle.io/stakater/bugs)
 # Stakater bugs
 
 Stakater has a large number of components. File issues here if you don't know the source of the problem.


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/stakater/bugs

This was requested by a real person (user hazim1093) on waffle.io, we're not trying to spam you.